### PR TITLE
Adjust regex to only catch zip or mov tld

### DIFF
--- a/adguardhome-block-zip-tld.txt
+++ b/adguardhome-block-zip-tld.txt
@@ -10,10 +10,10 @@
 ! https://medium.com/@bobbyrsec/the-dangers-of-googles-zip-tld-5e1e675e59a5                                !
 ! https://www.bleepingcomputer.com/news/security/new-zip-domains-spark-debate-among-cybersecurity-experts/ !
 ! -------------------------------------------------------------------------------------------------------- !
-/(\.|^)zip/$important
+/(\.|^)zip$/$important
 
 ! -------------------------------------------------------------------------------------------------------- !
 ! Block the new mov tld                                                                                    !
 ! Why? For the same reasons as the zip tld                                                                 !
 ! -------------------------------------------------------------------------------------------------------- !
-/(\.|^)mov/$important
+/(\.|^)mov$/$important

--- a/ublockorigin-block-zip-tld.txt
+++ b/ublockorigin-block-zip-tld.txt
@@ -10,10 +10,10 @@
 ! https://medium.com/@bobbyrsec/the-dangers-of-googles-zip-tld-5e1e675e59a5                                !
 ! https://www.bleepingcomputer.com/news/security/new-zip-domains-spark-debate-among-cybersecurity-experts/ !
 ! -------------------------------------------------------------------------------------------------------- !
-/(\.|^)zip/$important
+/(\.|^)zip$/$important
 
 ! -------------------------------------------------------------------------------------------------------- !
 ! Block the new mov tld                                                                                    !
 ! Why? For the same reasons as the zip tld                                                                 !
 ! -------------------------------------------------------------------------------------------------------- !
-/(\.|^)mov/$important
+/(\.|^)mov$/$important


### PR DESCRIPTION
Adjusted regex to only catch domains which are on the .zip or .mov tld's.

Currently any domain which is zip.tld or mov.tld will be caught by the original rules, this PR aims to fix that.

Real world example: [zip.co](https://zip.co/) is caught by the .zip rule prior to the changes in this PR.

Thanks.